### PR TITLE
lagt till "läs mer" på de beskrivningarna som är för långa

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -218,6 +218,7 @@ button:hover {
     margin-top: 15px;
     background-color: #e8f3e3;
     border: 1px solid #727070;
+    cursor: pointer;
     display: grid;
     grid-template-columns: 3fr 3fr 1fr;
     grid-template-rows: min-content min-content min-content min-content;
@@ -370,6 +371,14 @@ footer {
     grid-area: imgUrl;
     padding-right: 15px;
     padding-top: 20px;
+}
+
+i:hover {
+    text-decoration: underline;
+}
+
+input {
+    cursor: pointer;
 }
 
 

--- a/js/favoriter.js
+++ b/js/favoriter.js
@@ -46,7 +46,7 @@ async function showFavorites() {
         if (place.abstract == "") {
             shortDescription = "Ingen beskrivning tillgänglig";
         } else if (place.abstract.length > 100) {
-            shortDescription = place.abstract.substring(0, 100).trim() + "...";
+            shortDescription = place.abstract.substring(0, 100).trim() + "... <i>Läs mer</i>";
         } else {
             shortDescription = place.abstract.trim(); //annars använd hela beskrivningen
         }

--- a/js/formfunction.js
+++ b/js/formfunction.js
@@ -70,7 +70,7 @@ if (window.location.pathname.includes("quizresultat.html")) {
 
         // Om beskrivningen är längre än 100 tecken, kapa och lägg till "..."
         if (place.abstract.length > 100) {
-            shortDescription = place.abstract.substring(0, 100).trim() + "...";
+            shortDescription = place.abstract.substring(0, 100).trim() + "... <i>Läs mer</i>";
         } else {
             shortDescription = place.abstract.trim(); //annars använd hela beskrivningen
         }

--- a/js/list.js
+++ b/js/list.js
@@ -159,7 +159,7 @@ async function showPlaces(places) {
 
         // Om beskrivningen är längre än 100 tecken, kapa och lägg till "..."
         if (place.abstract.length > 100) {
-            shortDescription = place.abstract.substring(0, 100).trim() + "...";
+            shortDescription = place.abstract.substring(0, 100).trim() + "... <i>Läs mer</i>";
         } else {
             shortDescription = place.abstract.trim(); //annars använd hela beskrivningen
         }


### PR DESCRIPTION
Alla beskrivningar på resmåls "korten" som är för långa där det blir "..." har jag även lagt till en text "läs mer" med hover effekt för undeline så det ska se ut som en länk så man kan klicka på den, man kan även klicka på hela rutan